### PR TITLE
Added `categories` to DB and implemented server-side `category_id` referential integrity with `files` table and Added more specific errors

### DIFF
--- a/interfaces/Categories.ts
+++ b/interfaces/Categories.ts
@@ -1,0 +1,6 @@
+export interface Categories {
+	id: number;
+	name: string;
+	code?: string;
+	scope_level?: string;
+}

--- a/interfaces/FileMetadata.ts
+++ b/interfaces/FileMetadata.ts
@@ -3,6 +3,7 @@ export interface FileMetadata {
 	originalname: string;
 	uid?: string;
 	user_id: string;
+	category_id?: number;
 }
 
 export interface FileMetadataWithID extends Omit<FileMetadata, "uid"> {
@@ -10,4 +11,5 @@ export interface FileMetadataWithID extends Omit<FileMetadata, "uid"> {
 	created_at: Date;
 	uid: string;
 	downloadCount: number;
+	category_id: number;
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -3,7 +3,7 @@ import cors from "cors";
 import helmet from "helmet";
 
 import { routes } from "./routes";
-import { handleErrors } from "./middleware/handleErrors";
+import { handleErrors } from "./middleware/errors/handleErrors";
 
 const app: Application = express();
 

--- a/server/controller/addFileMetadata.ts
+++ b/server/controller/addFileMetadata.ts
@@ -4,10 +4,20 @@ import type {
 	FileMetadata,
 	FileMetadataWithID,
 } from "../../interfaces/FileMetadata";
+import { Categories } from "../../interfaces/Categories";
+import { BadRequestError } from "../middleware/errors/errors";
 
 const UID_LENGTH = 10;
 
 export const addFileMetadata = async (file: FileMetadata) => {
+	if (!file.category_id)
+		throw new BadRequestError("Category ID is not defined");
+
+	// this is the implementation of referential integrity on application level because PlanetScale doesn't support foreign keys
+	const isCategoryIdValid = await validateCategoryId(file.category_id);
+
+	if (!isCategoryIdValid) throw new BadRequestError("Category ID is not valid");
+
 	const generateAndCheckUIDCollision = async () => {
 		const uid = generateUID(UID_LENGTH);
 
@@ -28,4 +38,11 @@ const generateUID = (length: number) => {
 const isUIDConflicting = async (uid: string) => {
 	const files = await db<FileMetadataWithID>("files").where({ uid: uid });
 	return files.length > 0;
+};
+
+const validateCategoryId = async (categoryId: number) => {
+	const categories = await db<Categories>("categories").where({
+		id: categoryId,
+	});
+	return categories.length > 0;
 };

--- a/server/middleware/errors/errors.ts
+++ b/server/middleware/errors/errors.ts
@@ -1,0 +1,51 @@
+class HTTPError extends Error {
+	status!: number;
+	constructor(message: string) {
+		super(message);
+		this.message = message;
+	}
+}
+
+class BadRequestError extends HTTPError {
+	constructor(message = "Bad Request") {
+		super(message);
+		this.status = 400;
+	}
+}
+
+class UnauthorizedError extends HTTPError {
+	constructor(message = "Unauthorized") {
+		super(message);
+		this.status = 401;
+	}
+}
+
+class ForbiddenError extends HTTPError {
+	constructor(message = "Forbidden") {
+		super(message);
+		this.status = 403;
+	}
+}
+
+class NotFoundError extends HTTPError {
+	constructor(message = "Not Found") {
+		super(message);
+		this.status = 404;
+	}
+}
+
+class InternalServerError extends HTTPError {
+	constructor(message = "Internal Server Error") {
+		super(message);
+		this.status = 500;
+	}
+}
+
+export {
+	HTTPError,
+	BadRequestError,
+	UnauthorizedError,
+	ForbiddenError,
+	NotFoundError,
+	InternalServerError,
+};

--- a/server/middleware/errors/handleErrors.ts
+++ b/server/middleware/errors/handleErrors.ts
@@ -1,5 +1,6 @@
 import { ErrorRequestHandler, NextFunction, Request, Response } from "express";
 import { UnauthorizedError } from "express-oauth2-jwt-bearer";
+import { HTTPError } from "./errors";
 
 export const handleErrors: ErrorRequestHandler = (
 	err: Error,
@@ -9,12 +10,12 @@ export const handleErrors: ErrorRequestHandler = (
 	next: NextFunction
 ) => {
 	console.error(err.stack);
-	if (err instanceof UnauthorizedError) {
-		return res.status(err.statusCode).json({
+	if (err instanceof UnauthorizedError || err instanceof HTTPError) {
+		return res.status(err.status).json({
 			error: err.message,
 		});
 	}
-	res.status(500).json({
+	return res.status(500).json({
 		error: "Something went wrong",
 	});
 };

--- a/server/migrations/20230429122306_add_categories.ts
+++ b/server/migrations/20230429122306_add_categories.ts
@@ -1,0 +1,19 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+	return knex.schema
+		.createTable("categories", (table) => {
+			table.increments("id", { primaryKey: true });
+			table.text("name").notNullable();
+			table.string("code", 12);
+			table.string("scope_level", 24).defaultTo(null).nullable();
+		})
+		.alterTable("files", (table) => {
+			table.integer("category_id").unsigned();
+			// referencing foreign key is not supported by PlanetScale so we have to do it manually :(
+		});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	return knex.schema.dropTableIfExists("categories");
+}

--- a/server/migrations/20230429141959_refactor_files_table_attributes.ts
+++ b/server/migrations/20230429141959_refactor_files_table_attributes.ts
@@ -1,0 +1,27 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+	return knex.schema.alterTable("files", (table) => {
+		table.text("path").notNullable().alter();
+		table.string("originalname").notNullable().alter();
+		table
+			.timestamp("created_at")
+			.notNullable()
+			.defaultTo(knex.fn.now())
+			.alter();
+		table.string("uid", 10).notNullable().alter();
+		table.integer("downloadCount").notNullable().defaultTo(0).alter();
+		table.string("user_id").notNullable().alter();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	return knex.schema.alterTable("files", (table) => {
+		table.text("path").nullable().alter();
+		table.string("originalname").nullable().alter();
+		table.timestamp("created_at").nullable().defaultTo(knex.fn.now()).alter();
+		table.string("uid", 10).nullable().alter();
+		table.integer("downloadCount").nullable().defaultTo(0).alter();
+		table.string("user_id").nullable().alter();
+	});
+}

--- a/server/routes/upload/index.ts
+++ b/server/routes/upload/index.ts
@@ -8,6 +8,7 @@ import { db } from "../../middleware/knex/credentials";
 import { TypedRequestBody } from "../../interfaces/typedExpress";
 import { authMiddleware } from "../../middleware/jwt-bearer/authOptions";
 import { checkRequiredPermissions } from "../../middleware/auth0/checkPermissions";
+import { InternalServerError } from "../../middleware/errors/errors";
 
 const router: Router = Router();
 
@@ -16,19 +17,28 @@ router.post(
 	upload.single("file"),
 	authMiddleware,
 	checkRequiredPermissions(["upload:files"]),
-	async (req: TypedRequestBody<{ user_id: string }>, res: Response) => {
+	async (
+		req: TypedRequestBody<{ user_id: string; category_id: number }>,
+		res: Response
+	) => {
 		if (!req.file) return res.status(400).json({ message: "No file uploaded" });
 
-		const { user_id } = req.body;
-		const checkedUser_id = z.string().parse(user_id);
+		const { user_id, category_id } = req.body;
+		const checkedBody = z
+			.object({
+				user_id: z.string(),
+				category_id: z.number(),
+			})
+			.parse({ user_id, category_id });
 
 		const addedId = await addFileMetadata({
 			path: req.file.path,
 			originalname: req.file.originalname,
-			user_id: checkedUser_id,
+			user_id: checkedBody.user_id,
+			category_id: checkedBody.category_id,
 		});
 
-		if (!addedId) throw new Error("Failed to add file metadata");
+		if (!addedId) throw new InternalServerError("Failed to add file metadata");
 
 		const addedFile = await db<FileMetadataWithID>("files").where({
 			id: addedId[0],


### PR DESCRIPTION
### Added `categories` to DB 
though after some tinkering with the DB, I found out (with the help of ChatGPT) that PlanetScale doesn't allow foreign keys. So I implemented instead is an application-level referential integrity between `category_id` from `files` and `id` from `categories`

resolves #7, resolves #11
